### PR TITLE
feat(s3): add support for CRC64NVME checksum in S3 operations

### DIFF
--- a/cloud-nio/cloud-nio-spi/src/main/scala/cloud/nio/spi/HashType.scala
+++ b/cloud-nio/cloud-nio-spi/src/main/scala/cloud/nio/spi/HashType.scala
@@ -15,6 +15,8 @@ object HashType extends Enumeration {
   val Md5: HashType.Value = Value
   // AWS S3 etag
   val S3Etag: HashType.Value = Value
+  // AWS S3 CRC64NVME checksum
+  val S3CRC64NVME: HashType.Value = Value
   val Sha256: HashType.Value = Value
 
   implicit class HashTypeValue(hashType: Value) {
@@ -40,6 +42,10 @@ object HashType extends Enumeration {
           case _ =>
             s"${org.apache.commons.codec.digest.DigestUtils.md5Hex(parts.mkString)}-${numChunks}"
         }
+      case S3CRC64NVME =>
+        // Not needed to implement as checksums are obtained directly from S3 API responses
+        // and not calculated client-side for our S3 call caching use case
+        "Not implemented"
       case Sha256 =>
         MessageDigest.getInstance("SHA-256").digest(s.getBytes).map("%02x" format _).mkString
     }

--- a/cloud-nio/cloud-nio-spi/src/main/scala/cloud/nio/spi/HashType.scala
+++ b/cloud-nio/cloud-nio-spi/src/main/scala/cloud/nio/spi/HashType.scala
@@ -45,7 +45,7 @@ object HashType extends Enumeration {
       case S3CRC64NVME =>
         // Not needed to implement as checksums are obtained directly from S3 API responses
         // and not calculated client-side for our S3 call caching use case
-        "Not implemented"
+        s
       case Sha256 =>
         MessageDigest.getInstance("SHA-256").digest(s.getBytes).map("%02x" format _).mkString
     }

--- a/engine/src/main/scala/cromwell/engine/io/nio/NioFlow.scala
+++ b/engine/src/main/scala/cromwell/engine/io/nio/NioFlow.scala
@@ -184,7 +184,13 @@ class NioFlow(parallelism: Int,
         drsPath.getFileHash
       }.map(Option(_))
       case s3Path: S3Path => IO {
-        Option(FileHash(HashType.S3Etag, s3Path.eTag))
+        // Get checksum (CRC64NVME if available, otherwise eTag)
+        val checksum = s3Path.getChecksum
+        // Check if this is the CRC64NVME or eTag
+        if (checksum != s3Path.eTag)
+          Option(FileHash(HashType.S3CRC64NVME, checksum))
+        else
+          Option(FileHash(HashType.S3Etag, checksum))
       }
       case _ => IO.pure(None)
     }

--- a/filesystems/s3/src/main/java/org/lerch/s3fs/util/S3Utils.java
+++ b/filesystems/s3/src/main/java/org/lerch/s3fs/util/S3Utils.java
@@ -36,7 +36,11 @@ public class S3Utils {
         S3Client client = s3Path.getFileStore().getClient();
         // try to find the element with the current key (maybe with end slash or maybe not.)
         try {
-            HeadObjectResponse metadata = client.headObject(HeadObjectRequest.builder().bucket(bucketName).key(key).build());
+            HeadObjectResponse metadata = client.headObject(HeadObjectRequest.builder()
+                .bucket(bucketName)
+                .key(key)
+                .checksumMode(ChecksumMode.ENABLED)
+                .build());
             Owner objectOwner = Owner.builder().build();
             try {
                 GetObjectAclResponse acl = client.getObjectAcl(GetObjectAclRequest.builder().bucket(bucketName).key(key).build());
@@ -53,6 +57,11 @@ public class S3Utils {
                 .owner(objectOwner)
                 .size(metadata.contentLength())
                 .storageClass(metadata.storageClassAsString());
+
+            // Add the CRC64NVME checksum to the object if it's available
+            if (metadata.checksumCRC64NVME() != null) {
+                builder.checksumCRC64NVME(metadata.checksumCRC64NVME());
+            }
 
             return builder.build();
         } catch (S3Exception e) {

--- a/filesystems/s3/src/main/scala/cromwell/filesystems/s3/S3PathBuilder.scala
+++ b/filesystems/s3/src/main/scala/cromwell/filesystems/s3/S3PathBuilder.scala
@@ -179,6 +179,14 @@ case class S3Path private[s3](nioPath: NioPath,
 
   lazy val eTag = new S3Utils().getS3ObjectSummary(s3Path).eTag()
 
+  /**
+   * Get the checksum for this file, preferring CRC64NVME when available, otherwise falling back to eTag
+   */
+  lazy val getChecksum = {
+    val summary = new S3Utils().getS3ObjectSummary(s3Path)
+    Option(summary.checksumCRC64NVME()) getOrElse summary.eTag()
+  }
+
   /** Gets an absolute path for multiple forms of input. The FS provider does
    *  not support "toAbsolutePath" on forms such as "mypath/" or "foo.bar"
    *  So this function will prepend a forward slash for input that looks like this

--- a/filesystems/s3/src/main/scala/cromwell/filesystems/s3/batch/S3BatchCommandBuilder.scala
+++ b/filesystems/s3/src/main/scala/cromwell/filesystems/s3/batch/S3BatchCommandBuilder.scala
@@ -79,7 +79,7 @@ private case object PartialS3BatchCommandBuilder extends PartialIoCommandBuilder
   }
 
   override def hashCommand: PartialFunction[Path, Try[IoHashCommand]] = {
-    case s3_path: S3Path => Try(S3BatchEtagCommand(s3_path).asInstanceOf[IoHashCommand])
+    case s3_path: S3Path => Try(S3BatchChecksumCommand(s3_path).asInstanceOf[IoHashCommand])
     case local_path: Path => Try(DefaultIoHashCommand(local_path))
   }
 

--- a/filesystems/s3/src/main/scala/cromwell/filesystems/s3/batch/S3BatchIoCommand.scala
+++ b/filesystems/s3/src/main/scala/cromwell/filesystems/s3/batch/S3BatchIoCommand.scala
@@ -113,6 +113,18 @@ case class S3BatchEtagCommand(override val file: S3Path) extends IoHashCommand(f
 }
 
 /**
+  * `IoCommand` to find the checksum of an s3 object (preferring CRC64NVME if available, with fallback to Etag)
+  * @param file the path to the object
+  */
+case class S3BatchChecksumCommand(override val file: S3Path) extends IoHashCommand(file) with S3BatchHeadCommand[String] {
+  override def mapResponse(response: HeadObjectResponse): String = {
+    // First check for CRC64NVME (the bucket default) and fall back to etag
+    Option(response.checksumCRC64NVME()).getOrElse(response.eTag())
+  }
+  override def commandDescription: String = s"S3BatchChecksumCommand file '$file'"
+}
+
+/**
   * `IoCommand` to "touch" an S3 object. The current implementation of `mapResponse` in this object doesn't do anything
   * as it is not clear that touch is meaningful in the context of S3
   * @param file the path to the object


### PR DESCRIPTION
- Introduced S3CRC64NVME hash type in HashType enumeration.
- Updated S3Path to prefer CRC64NVME checksum when available.
- Modified NioFlow to utilize the new checksum logic for S3 paths.
- Enhanced S3Utils to retrieve CRC64NVME checksum from S3 metadata.
- Created S3BatchChecksumCommand to handle checksum retrieval for S3 objects.

This change improves checksum handling for S3 objects, ensuring more accurate file integrity verification.